### PR TITLE
Add `X-Accel-Buffering` header to SSE response

### DIFF
--- a/src/resources/model_template_refresh_resource.cr
+++ b/src/resources/model_template_refresh_resource.cr
@@ -7,6 +7,7 @@ module Crumble
         ctx.response.content_type = "text/event-stream"
         ctx.response.headers["Cache-Control"] = "no-cache"
         ctx.response.headers["Connection"] = "keep-alive"
+        ctx.response.headers["X-Accel-Buffering"] = "no"
 
         ctx.response.upgrade do |io|
           channel = ModelTemplateRefreshService.subscribe(ctx.session.id.to_s)


### PR DESCRIPTION
This should prevent nginx from buffering response data, beating the purpose of SSE in the first place.