### PR TITLE
Auto-refresh all templates after subscription

### DIFF
--- a/spec/crumble/turbo/model_template_refresh_resource_spec.cr
+++ b/spec/crumble/turbo/model_template_refresh_resource_spec.cr
@@ -18,6 +18,51 @@ module Crumble::Turbo::ModelTemplateRefreshResourceSpec
       MyModel.continuous_migration!
     end
 
+    it "should initially refresh registered model templates" do
+      model = MyModel.create(id: 14_i64, name: "Yoda")
+
+      session_store = ::Crumble::Server::MemorySessionStore.new
+      session = ::Crumble::Server::Session.new
+      session_store.set(session)
+
+      res_str = String.build do |res_io|
+        headers = HTTP::Headers.new
+        cookies = HTTP::Cookies.new
+        cookies[::Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = session.id.to_s
+        cookies.add_request_headers(headers)
+
+        ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "GET", response_io: res_io, headers: headers, session_store: session_store)
+        ModelTemplateRefreshResource.handle(ctx)
+
+        # Simulate HTTP::Server::RequestProcessor
+        spawn do
+          if upgrade_handler = ctx.response.upgrade_handler
+            upgrade_handler.call(res_io)
+          end
+        end
+
+        post_ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "POST", body: "[\"#{model.the_view.dom_id.attr_value}\"]", headers: headers, session_store: session_store)
+        ModelTemplateRefreshResource.handle(post_ctx)
+
+        3.times { Fiber.yield }
+      end
+
+      expected_html = <<-HTML.squish
+      <turbo-stream action="replace" targets="[data-model-template-id='Crumble::Turbo::ModelTemplateRefreshResourceSpec::MyModel#14-the_view']">
+        <template>
+          <div data-model-template-id="Crumble::Turbo::ModelTemplateRefreshResourceSpec::MyModel#14-the_view" data-crumble--turbo--model-template-refresh-target="modelTemplate">
+            <div>
+              <span>Yoda</span>
+              <span>#{ModelTemplateRefreshResource.uri_path}</span>
+            </div>
+          </div>
+        </template>
+      </turbo-stream>
+      HTML
+
+      res_str.should contain(expected_html)
+    end
+
     it "should receive a model template refresh turbo stream" do
       model = MyModel.create(id: 13_i64, name: "Yoda")
 

--- a/src/crumble/turbo/model_template_refresh_service.cr
+++ b/src/crumble/turbo/model_template_refresh_service.cr
@@ -10,7 +10,6 @@ module Crumble
       @@model_template_subscriptions = {} of String => Set(::Crumble::Server::SessionKey)
 
       def self.subscribe(ctx : ::Crumble::Server::HandlerContext) : Channel(TurboStream(IdentifiableView))
-
         id = ctx.session.id
 
         if existing_subscription = @@subscriptions[id]?
@@ -36,19 +35,62 @@ module Crumble
         (@@model_template_subscriptions[model_template_id] ||= Set(::Crumble::Server::SessionKey).new) << ctx.session.id
       end
 
-      def self.refresh_model_template(model_class_name : String, model_id, template_name : String)
+      def self.refresh_model_template_id(model_template_id : String, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil) : Nil
+        return unless parsed = parse_model_template_id(model_template_id)
+
+        model_class_name, model_id_str, template_name = parsed
+        refresh_model_template(model_class_name, model_id_str, template_name, only: only)
+      end
+
+      def self.refresh_model_template(model_class_name : String, model_id : String | Int32 | Int64, template_name : String, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil)
         {% begin %}
           case model_class_name
             {% for klass in ::Orma::Record.all_subclasses.reject(&.abstract?) %}
             when {{klass.name.stringify}}
-              %model = {{klass}}.where(id: model_id).first?
+              {% id_ivar = klass.instance_vars.find { |v| v.name == "id".id } %}
+              {% unless id_ivar %}
+                {% next %}
+              {% end %}
+
+              {% id_attr_type = id_ivar.type.resolve %}
+              {% if id_attr_type.nilable? %}
+                {% id_attr_type = id_attr_type.union_types.find { |t| t != Nil } %}
+              {% end %}
+              {% id_value_type = id_attr_type.type_vars[0] %}
+
+              %id =
+                {% if id_value_type == Int32 %}
+                  case model_id
+                  when String
+                    model_id.to_i?
+                  when Int32
+                    model_id
+                  when Int64
+                    if model_id >= Int32::MIN && model_id <= Int32::MAX
+                      model_id.to_i
+                    end
+                  end
+                {% else %}
+                  case model_id
+                  when String
+                    model_id.to_i64?
+                  when Int32
+                    model_id.to_i64
+                  when Int64
+                    model_id
+                  end
+                {% end %}
+
+              return unless %id
+
+              %model = {{klass}}.where(id: %id).first?
 
               return unless %model
 
               case template_name
                 {% for method in klass.methods.select { |m| m.annotation(::Orma::Record::ModelTemplateMethod) } %}
                 when {{method.name.stringify}}
-                  notify(%model.{{method.name}})
+                  notify(%model.{{method.name}}, only: only)
                 {% end %}
               end
             {% end %}
@@ -56,24 +98,65 @@ module Crumble
         {% end %}
       end
 
-      def self.notify(model_template)
+      def self.notify(model_template, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil)
         return unless ids = @@model_template_subscriptions[model_template.dom_id.attr_value]?
 
-        ids.each do |id|
-          if (subscription = @@subscriptions[id]?) && !subscription.channel.closed?
-            spawn do
-              subscription.channel.send(model_template.renderer(subscription.ctx).turbo_stream)
-            rescue e : Channel::ClosedError
-              # discard
-            end
-          else
-            ids.delete(id)
+        stale_ids = Set(::Crumble::Server::SessionKey).new
 
-            if subscription && subscription.channel.closed?
-              @@subscriptions.delete(id)
-            end
+        case only
+        in Nil
+          ids.each do |id|
+            stale_ids << id unless send_model_template_to_subscription(model_template, id)
+          end
+        in ::Crumble::Server::SessionKey
+          id = only
+          return unless ids.includes?(id)
+
+          stale_ids << id unless send_model_template_to_subscription(model_template, id)
+        in Enumerable(::Crumble::Server::SessionKey)
+          only.each do |id|
+            next unless ids.includes?(id)
+
+            stale_ids << id unless send_model_template_to_subscription(model_template, id)
           end
         end
+
+        stale_ids.each do |id|
+          ids.delete(id)
+
+          if (subscription = @@subscriptions[id]?) && subscription.channel.closed?
+            @@subscriptions.delete(id)
+          end
+        end
+      end
+
+      private def self.send_model_template_to_subscription(model_template, id : ::Crumble::Server::SessionKey) : Bool
+        return false unless subscription = @@subscriptions[id]?
+        return false if subscription.channel.closed?
+
+        spawn do
+          subscription.channel.send(model_template.renderer(subscription.ctx).turbo_stream)
+        rescue e : Channel::ClosedError
+          # discard
+        end
+
+        true
+      end
+
+      private def self.parse_model_template_id(model_template_id : String) : {String, String, String}?
+        hash_index = model_template_id.index('#')
+        return unless hash_index
+
+        dash_index = model_template_id.index('-', hash_index + 1)
+        return unless dash_index
+
+        model_class_name = model_template_id[0, hash_index]
+        model_id_str = model_template_id[(hash_index + 1)...dash_index]
+        template_name = model_template_id[(dash_index + 1)..]
+
+        return if model_class_name.empty? || model_id_str.empty? || template_name.empty?
+
+        {model_class_name, model_id_str, template_name}
       end
     end
   end

--- a/src/resources/model_template_refresh_resource.cr
+++ b/src/resources/model_template_refresh_resource.cr
@@ -17,6 +17,9 @@ module Crumble
             io.sync = true
           end
 
+          io << ": connected\n\n"
+          io.flush
+
           loop do
             turbo_stream = channel.receive
 

--- a/src/resources/model_template_refresh_resource.cr
+++ b/src/resources/model_template_refresh_resource.cr
@@ -29,7 +29,6 @@ module Crumble
 
             break
           end
-
         rescue Channel::ClosedError
         ensure
           channel.close
@@ -44,6 +43,7 @@ module Crumble
 
         model_template_ids.each do |model_template_id|
           ModelTemplateRefreshService.register(ctx, model_template_id)
+          ModelTemplateRefreshService.refresh_model_template_id(model_template_id, only: ctx.session.id)
         end
       end
     end

--- a/src/stimulus_controllers/model_template_refresh_controller.cr
+++ b/src/stimulus_controllers/model_template_refresh_controller.cr
@@ -11,7 +11,8 @@ module Crumble
 
         that = this
         this.evt_source.addEventListener("open") do
-          that.register_model_templates(true)
+          that.connected = true
+          that.register_model_templates._call
         end
       end
 
@@ -28,10 +29,10 @@ module Crumble
           return elem.dataset["modelTemplateId"]
         end.sort._call
 
-        model_template_ids_changed = this.model_template_ids.length != model_template_ids.length
+        model_template_ids_changed = (this.model_template_ids.length != model_template_ids.length)
         unless model_template_ids_changed
           model_template_ids_changed = this.model_template_ids.every do |index, value|
-            model_template_ids[index] == value
+            return model_template_ids[index] == value
           end
         end
 
@@ -49,11 +50,11 @@ module Crumble
       end
 
       js_method :modelTemplateTargetConnected do
-        this.register_model_templates._call
+        this.register_model_templates._call if this.connected
       end
 
       js_method :modelTemplateTargetDisconnected do
-        this.register_model_templates._call
+        this.register_model_templates._call if this.connected
       end
     end
   end


### PR DESCRIPTION
This ensures fresh data is presented even if the page was loaded from a cache on client side.