### PR TITLE
Reset action forms after successful submit

### DIFF
--- a/spec/action_form_request_spec.cr
+++ b/spec/action_form_request_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 module Crumble::Turbo::ActionFormRequestSpec
   class PayloadAction < Crumble::Turbo::Action
     form do
-      field name : String
+      field name : String, allow_blank: false
     end
 
     controller do
@@ -50,6 +50,35 @@ module Crumble::Turbo::ActionFormRequestSpec
       form.name.should be_nil
       form.valid?.should be_false
       form.errors.should eq(["name"])
+    end
+
+    it "resets the form after a valid submit before refreshing the template" do
+      response = String.build do |io|
+        body = URI::Params.encode({name: "Alice"})
+        ctx = Crumble::Server::TestRequestContext.new(method: "POST", resource: PayloadAction.uri_path, body: body, response_io: io)
+        action = PayloadAction.new(ctx)
+        action.handle
+        action.form.name.should be_nil
+        ctx.response.flush
+      end
+
+      response.should contain(%(name="name" value=""))
+      response.should_not contain(%(value="Alice"))
+      response.should_not contain("crumble--field-errors")
+    end
+
+    it "preserves submitted values and errors after an invalid submit" do
+      response = String.build do |io|
+        body = URI::Params.encode({name: ""})
+        ctx = Crumble::Server::TestRequestContext.new(method: "POST", resource: PayloadAction.uri_path, body: body, response_io: io)
+        action = PayloadAction.new(ctx)
+        action.handle
+        action.form.name.should eq("")
+        action.form.errors.should eq(["name"])
+        ctx.response.flush
+      end
+
+      response.should contain("crumble--field-errors")
     end
   end
 end

--- a/spec/orma/create_child_action_spec.cr
+++ b/spec/orma/create_child_action_spec.cr
@@ -168,6 +168,22 @@ describe "MyModel #add_child_action_template" do
       response.should contain(%(<option value="Allowed">Allowed</option>))
     end
 
+    it "resets submitted values after a valid model-aware form request" do
+      model = CreateChildSpec::MyModel.create(name: "Allowed")
+      response = String.build do |io|
+        ctx = Crumble::Server::TestRequestContext.new(method: "POST", resource: "/a/create_child_spec/my_model/#{model.id.value}/add_child_with_dynamic_options", body: URI::Params.encode({name: "Allowed"}), response_io: io)
+        CreateChildSpec::MyModel::AddChildWithDynamicOptionsAction.handle(ctx)
+        ctx.response.status_code.should eq(201)
+        ctx.response.flush
+      end
+
+      CreateChildSpec::ChildModel.where(my_model_id: model.id.value).count.should eq(1)
+      response.should contain(%(<option value="" selected>Pick a name</option>))
+      response.should contain(%(<option value="Allowed">Allowed</option>))
+      response.should_not contain(%(<option value="Allowed" selected>Allowed</option>))
+      response.should_not contain(%(<div class="errors">))
+    end
+
     it "creates children from model-aware forms without extra action ivars" do
       model = CreateChildSpec::MyModel.create(name: "Allowed")
       mock_ctx = Crumble::Server::TestRequestContext.new(method: "POST", resource: "/a/create_child_spec/my_model/#{model.id.value}/add_child_with_dynamic_options", body: URI::Params.encode({name: "Allowed"}))

--- a/src/crumble/turbo/action.cr
+++ b/src/crumble/turbo/action.cr
@@ -123,6 +123,12 @@ module Crumble::Turbo
           Form.new(ctx)
         end
       end
+
+      def reset_form_after_successful_submit
+        return unless (request_form = form).submitted? && request_form.valid?
+
+        @form = nil
+      end
     end
 
     macro view(&blk)
@@ -167,6 +173,7 @@ module Crumble::Turbo
       end
 
       self.controller
+      reset_form_after_successful_submit
       refresh_template
     end
 
@@ -201,6 +208,9 @@ module Crumble::Turbo
     def redirect(new_path)
       ctx.response.status_code = 303
       ctx.response.headers["Location"] = new_path
+    end
+
+    def reset_form_after_successful_submit
     end
 
     # Crumble::Server::ViewHandler method

--- a/src/crumble/turbo/action.cr
+++ b/src/crumble/turbo/action.cr
@@ -3,6 +3,14 @@ require "./action_form"
 require "./custom_action_trigger"
 
 module Crumble::Turbo
+  module RequestBackedFormReset
+    def reset_form
+      return unless (request_form = form).submitted? && request_form.valid?
+
+      @form = nil
+    end
+  end
+
   abstract class Action
     include Crumble::Server::ViewHandler
 
@@ -124,11 +132,7 @@ module Crumble::Turbo
         end
       end
 
-      def reset_form_after_successful_submit
-        return unless (request_form = form).submitted? && request_form.valid?
-
-        @form = nil
-      end
+      include ::Crumble::Turbo::RequestBackedFormReset
     end
 
     macro view(&blk)
@@ -173,7 +177,7 @@ module Crumble::Turbo
       end
 
       self.controller
-      reset_form_after_successful_submit
+      reset_form
       refresh_template
     end
 
@@ -210,7 +214,7 @@ module Crumble::Turbo
       ctx.response.headers["Location"] = new_path
     end
 
-    def reset_form_after_successful_submit
+    def reset_form
     end
 
     # Crumble::Server::ViewHandler method

--- a/src/orma/model_action.cr
+++ b/src/orma/model_action.cr
@@ -62,11 +62,7 @@ module Orma
         end
       end
 
-      def reset_form_after_successful_submit
-        return unless (request_form = form).submitted? && request_form.valid?
-
-        @form = nil
-      end
+      include ::Crumble::Turbo::RequestBackedFormReset
     end
 
     def initialize(ctx : ::Crumble::Server::HandlerContext, @model)

--- a/src/orma/model_action.cr
+++ b/src/orma/model_action.cr
@@ -61,6 +61,12 @@ module Orma
           Form.new(ctx, model)
         end
       end
+
+      def reset_form_after_successful_submit
+        return unless (request_form = form).submitted? && request_form.valid?
+
+        @form = nil
+      end
     end
 
     def initialize(ctx : ::Crumble::Server::HandlerContext, @model)


### PR DESCRIPTION
## Summary

- reset memoized request-backed action forms after the controller runs when the submitted form is valid
- keep invalid submitted forms intact so refreshed templates still show the submitted values and validation errors
- add regression specs for both plain actions and model-aware actions

## Testing

- `CRYSTAL_CACHE_DIR=/tmp/crt-crystal-cache crystal spec`