### PR TITLE
Trace SSE model template transmissions

### DIFF
--- a/spec/crumble/turbo/model_template_refresh_resource_spec.cr
+++ b/spec/crumble/turbo/model_template_refresh_resource_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "json"
 
 module Crumble::Turbo::ModelTemplateRefreshResourceSpec
   class MyModel < TestRecord
@@ -20,6 +21,31 @@ module Crumble::Turbo::ModelTemplateRefreshResourceSpec
     model_template :the_view do
       pre { transcript }
     end
+  end
+
+  def self.exported_traces(memory : IO::Memory)
+    memory.rewind
+    buffer = memory.gets_to_end
+    traces = [] of JSON::Any
+    start_pos = -1
+    depth = 0
+
+    # The IO exporter writes trace JSON objects back-to-back without separators.
+    # Track object depth so specs can inspect each exported trace independently.
+    buffer.each_char_with_index do |char, index|
+      if char == '{'
+        start_pos = index if depth == 0
+        depth += 1
+      elsif char == '}'
+        depth -= 1
+        if depth == 0 && start_pos >= 0
+          traces << JSON.parse(buffer[start_pos..index])
+          start_pos = -1
+        end
+      end
+    end
+
+    traces.reject { |trace| trace.size == 0 }
   end
 
   describe "when an SSE connection is open" do
@@ -189,6 +215,59 @@ module Crumble::Turbo::ModelTemplateRefreshResourceSpec
 
       decoded_payload = encoded_payload.gsub("&#13;", "\r").gsub("&#10;", "\n")
       decoded_payload.should contain("<pre>line 1\r\nline 2\r\nline 3</pre>")
+    end
+
+    it "creates linked root spans for model template transmissions" do
+      model = MyModel.create(name: "Yoda")
+      memory = IO::Memory.new
+      original_config = OpenTelemetry.config
+      original_provider = OpenTelemetry.provider
+
+      begin
+        OpenTelemetry.configure do |config|
+          config.exporter = OpenTelemetry::Exporter.new(variant: :io, io: memory)
+        end
+
+        session_store = ::Crumble::Server::MemorySessionStore.new
+        session = ::Crumble::Server::Session.new
+        session_store.set(session)
+        headers = HTTP::Headers.new
+        cookies = HTTP::Cookies.new
+        cookies[::Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = session.id.to_s
+        cookies.add_request_headers(headers)
+        ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "GET", response_io: IO::Memory.new, headers: headers, session_store: session_store)
+
+        OpenTelemetry.tracer.in_span("GET #{ModelTemplateRefreshResource.uri_path}") do |span|
+          span.server!
+          ModelTemplateRefreshResource.handle(ctx)
+        end
+
+        spawn do
+          if upgrade_handler = ctx.response.upgrade_handler
+            upgrade_handler.call(IO::Memory.new)
+          end
+        end
+
+        post_ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "POST", body: "[\"#{model.the_view.dom_id.attr_value}\"]", headers: headers, session_store: session_store)
+        ModelTemplateRefreshResource.handle(post_ctx)
+        3.times { Fiber.yield }
+
+        spans = exported_traces(memory).flat_map { |trace| trace["spans"].as_a }
+        connection_span = spans.find { |span| span["name"].as_s == "GET #{ModelTemplateRefreshResource.uri_path}" }.not_nil!
+        template_span = spans.find { |span| span["name"].as_s == "SSE model template transmission" }.not_nil!
+
+        template_span["traceId"].as_s.should eq(connection_span["traceId"].as_s)
+        template_span["parentSpanId"].raw.should be_nil
+        template_span["attributes"]["crumble.turbo.model_template.id"].as_s.should eq(model.the_view.dom_id.attr_value)
+        template_span["links"].as_a.size.should eq(1)
+        template_span["links"][0]["traceId"].as_s.should eq(connection_span["traceId"].as_s)
+        template_span["links"][0]["spanId"].as_s.should eq(connection_span["spanId"].as_s)
+      ensure
+        OpenTelemetry.config = original_config
+        OpenTelemetry.provider = original_provider
+        Fiber.current.current_trace = nil
+        Fiber.current.current_span = nil
+      end
     end
   end
 end

--- a/src/crumble/turbo/model_template_refresh_service.cr
+++ b/src/crumble/turbo/model_template_refresh_service.cr
@@ -1,10 +1,11 @@
 require "../../turbo_stream"
 require "../../orma/model_template"
+require "opentelemetry-sdk"
 
 module Crumble
   module Turbo
     module ModelTemplateRefreshService
-      record Subscription, ctx : ::Crumble::Server::HandlerContext, channel : Channel(TurboStream(IdentifiableView))
+      record Subscription, ctx : ::Crumble::Server::HandlerContext, channel : Channel(TurboStream(IdentifiableView)), connection_span_context : OpenTelemetry::SpanContext?
 
       @@subscriptions = {} of ::Crumble::Server::SessionKey => Subscription
       @@model_template_subscriptions = {} of String => Set(::Crumble::Server::SessionKey)
@@ -17,7 +18,7 @@ module Crumble
         end
 
         channel = Channel(TurboStream(IdentifiableView)).new
-        @@subscriptions[id] = Subscription.new(ctx, channel)
+        @@subscriptions[id] = Subscription.new(ctx, channel, OpenTelemetry.current_span.try(&.context))
 
         channel
       end
@@ -135,12 +136,32 @@ module Crumble
         return false if subscription.channel.closed?
 
         spawn do
-          subscription.channel.send(model_template.renderer(subscription.ctx).turbo_stream)
+          trace = trace_for_model_template_send(subscription)
+          trace.in_span("SSE model template transmission") do |span|
+            span.producer!
+            span["crumble.turbo.model_template.id"] = model_template.dom_id.attr_value
+            span["crumble.session.id"] = id.to_s
+            if connection_span_context = subscription.connection_span_context
+              span.add_link(connection_span_context, {"crumble.link.type" => "sse.connection"})
+            end
+
+            subscription.channel.send(model_template.renderer(subscription.ctx).turbo_stream)
+          end
         rescue e : Channel::ClosedError
           # discard
         end
 
         true
+      end
+
+      private def self.trace_for_model_template_send(subscription) : OpenTelemetry::Trace
+        trace = OpenTelemetry.trace_provider.trace
+        if connection_span_context = subscription.connection_span_context
+          trace.trace_id = connection_span_context.trace_id
+          trace.span_context.trace_id = connection_span_context.trace_id
+        end
+
+        trace
       end
 
       private def self.parse_model_template_id(model_template_id : String) : {String, String, String}?

--- a/src/ext/open_telemetry/span_links.cr
+++ b/src/ext/open_telemetry/span_links.cr
@@ -1,0 +1,79 @@
+module OpenTelemetry
+  class Span
+    getter links : Array(Proto::Trace::V1::Span::Link) = [] of Proto::Trace::V1::Span::Link
+
+    # The pinned SDK protobuf supports links, but Span does not expose them yet.
+    # Keep the extension local so template send spans can export link metadata.
+    def add_link(context : SpanContext, attributes : Hash(String, AnyAttribute) = {} of String => AnyAttribute) : Nil
+      links << Proto::Trace::V1::Span::Link.new(trace_id: context.trace_id, span_id: context.span_id, trace_state: context.trace_state.map { |key, value| "#{key}=#{value}" }.join(","), attributes: attributes.map do |key, value|
+        Proto::Common::V1::KeyValue.new(key: key, value: Attribute.to_anyvalue(value))
+      end)
+    end
+
+    def add_link(context : SpanContext, attributes : Hash(String, _) = {} of String => String) : Nil
+      converted_attributes = {} of String => AnyAttribute
+      attributes.each do |key, value|
+        converted_attributes[key] = AnyAttribute.new(key: key, value: value)
+      end
+
+      add_link(context, converted_attributes)
+    end
+
+    def to_protobuf
+      return unless can_export?
+
+      span = Proto::Trace::V1::Span.new(name: name, trace_id: context.trace_id, span_id: context.span_id, parent_span_id: parent.try(&.context.span_id), start_time_unix_nano: start_time_unix_nano, end_time_unix_nano: end_time_unix_nano, kind: pb_span_kind, status: status.to_protobuf)
+      span.attributes = attributes.map do |key, value|
+        Proto::Common::V1::KeyValue.new(key: key, value: Attribute.to_anyvalue(value))
+      end
+      span.events = events.map(&.to_protobuf)
+      span.links = links
+      span
+    end
+
+    def to_json(json : JSON::Builder)
+      if can_export?
+        json.object do
+          json.field "type", "span"
+          json.field "traceId", context.trace_id.hexstring
+          json.field "spanId", context.span_id.hexstring
+          json.field "parentSpanId", parent.try(&.context.span_id.hexstring)
+          json.field "kind", kind.value
+          json.field "name", name
+          json.field "status", status.to_json
+          json.field "startTime", start_time_unix_nano
+          json.field "endTime", end_time_unix_nano
+          json.field "attributes" do
+            json.object do
+              attributes.each do |_, value|
+                json.field value.key, value.value
+              end
+            end
+          end
+          json.field "events" do
+            json.array do
+              events.each do |event|
+                event.to_json(json)
+              end
+            end
+          end
+          json.field "links" do
+            json.array do
+              links.each do |link|
+                json.object do
+                  json.field "traceId", link.trace_id.try(&.hexstring)
+                  json.field "spanId", link.span_id.try(&.hexstring)
+                  json.field "traceState", link.trace_state
+                end
+              end
+            end
+          end
+          json
+        end
+      else
+        json.object do
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add span-link support for the pinned OpenTelemetry SDK span export path.
- Capture the SSE connection span context when subscribing.
- Create root spans for each model template transmission and link them back to the connection span.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crystal-cache- crystal spec --error-trace`