### PR TITLE
Reload sessions before template refreshes

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ license: MIT
 dependencies:
   crumble:
     github: sbsoftware/crumble
-    version: ">= 0.32.0, < 0.33.0"
+    version: ">= 0.32.0"
   to_html:
     github: sbsoftware/to_html.cr
     version: ">= 1.4.0, < 2.0.0"

--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ license: MIT
 dependencies:
   crumble:
     github: sbsoftware/crumble
-    version: ">= 0.31.0"
+    version: ">= 0.32.0, < 0.33.0"
   to_html:
     github: sbsoftware/to_html.cr
     version: ">= 1.4.0, < 2.0.0"

--- a/spec/crumble/turbo/model_template_refresh_resource_spec.cr
+++ b/spec/crumble/turbo/model_template_refresh_resource_spec.cr
@@ -14,6 +14,17 @@ module Crumble::Turbo::ModelTemplateRefreshResourceSpec
     end
   end
 
+  class SessionModel < TestRecord
+    id_column id : Int64
+    column name : String
+
+    model_template :the_view do
+      div do
+        span { ctx.session.model_template_refresh_value }
+      end
+    end
+  end
+
   class MultilineModel < TestRecord
     id_column id : Int64
     column transcript : String
@@ -132,6 +143,56 @@ module Crumble::Turbo::ModelTemplateRefreshResourceSpec
             <div>
               <span>Yoda</span>
               <span>#{ModelTemplateRefreshResource.uri_path}</span>
+            </div>
+          </div>
+        </template>
+      </turbo-stream>
+      HTML
+
+      res_str.should contain(expected_html)
+    end
+
+    it "reloads the subscriber session before rendering model template refreshes" do
+      model = SessionModel.create(name: "Yoda")
+
+      session_store = ::Crumble::Server::MemorySessionStore.new
+      session = ::Crumble::Server::Session.new
+      session.update!(model_template_refresh_value: "initial")
+      session_store.set(session)
+
+      res_str = String.build do |res_io|
+        headers = HTTP::Headers.new
+        cookies = HTTP::Cookies.new
+        cookies[::Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = session.id.to_s
+        cookies.add_request_headers(headers)
+
+        ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "GET", response_io: res_io, headers: headers, session_store: session_store)
+        ModelTemplateRefreshResource.handle(ctx)
+
+        spawn do
+          if upgrade_handler = ctx.response.upgrade_handler
+            upgrade_handler.call(res_io)
+          end
+        end
+
+        post_ctx = ::Crumble::Server::TestRequestContext.new(resource: ModelTemplateRefreshResource.uri_path, method: "POST", body: "[\"#{model.the_view.dom_id.attr_value}\"]", headers: headers, session_store: session_store)
+        ModelTemplateRefreshResource.handle(post_ctx)
+
+        updated_session = ::Crumble::Server::Session.new(session.id)
+        updated_session.update!(model_template_refresh_value: "updated")
+        session_store.set(updated_session)
+
+        model.the_view.refresh!
+
+        3.times { Fiber.yield }
+      end
+
+      expected_html = <<-HTML.squish
+      <turbo-stream action="replace" targets="[data-model-template-id='Crumble::Turbo::ModelTemplateRefreshResourceSpec::SessionModel##{model.id.value}-the_view']">
+        <template>
+          <div data-model-template-id="Crumble::Turbo::ModelTemplateRefreshResourceSpec::SessionModel##{model.id.value}-the_view" data-crumble--turbo--model-template-refresh-target="modelTemplate">
+            <div>
+              <span>updated</span>
             </div>
           </div>
         </template>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,6 +13,10 @@ class String
   end
 end
 
+class Crumble::Server::Session
+  property model_template_refresh_value : String?
+end
+
 abstract class TestRecord < Orma::Record
   macro inherited
     {% unless @type.abstract? %}

--- a/src/crumble/turbo/model_template_refresh_service.cr
+++ b/src/crumble/turbo/model_template_refresh_service.cr
@@ -145,6 +145,7 @@ module Crumble
               span.add_link(connection_span_context, {"crumble.link.type" => "sse.connection"})
             end
 
+            subscription.ctx.session.reload
             subscription.channel.send(model_template.renderer(subscription.ctx).turbo_stream)
           end
         rescue e : Channel::ClosedError


### PR DESCRIPTION
## Summary
- Reload subscriber sessions before rendering model template refresh broadcasts
- Require Crumble 0.32.x for session reload support
- Add a regression spec covering session changes after subscription

## Tests
- `shards check`
- `CRYSTAL_CACHE_DIR=/tmp/crt-crystal-cache crystal spec`