### PR TITLE
Avoid duplicate model action template refreshes

### DIFF
--- a/spec/orma/model_action_spec.cr
+++ b/spec/orma/model_action_spec.cr
@@ -131,6 +131,62 @@ module Orma::ModelActionSpec
       res.should_not contain("data-model-template-id")
       res.should contain("data-model-action-template-id")
     end
+
+    it "does not broadcast a model template refresh back to the submitting session" do
+      model = Orma::ModelActionSpec::MyModel.create(some_number: 3)
+      model_id = model.id.value
+      model_template_id = model.some_number_view.dom_id.attr_value
+      session_store = Crumble::Server::MemorySessionStore.new
+      submitting_session = Crumble::Server::Session.new
+      other_session = Crumble::Server::Session.new
+      session_store.set(submitting_session)
+      session_store.set(other_session)
+      submitting_headers = HTTP::Headers.new
+      other_headers = HTTP::Headers.new
+      submitting_cookies = HTTP::Cookies.new
+      other_cookies = HTTP::Cookies.new
+      submitting_cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = submitting_session.id.to_s
+      other_cookies[Crumble::Server::RequestContext::SESSION_COOKIE_NAME] = other_session.id.to_s
+      submitting_cookies.add_request_headers(submitting_headers)
+      other_cookies.add_request_headers(other_headers)
+      submitting_subscriber_request_ctx = Crumble::Server::TestRequestContext.new(method: "GET", resource: Crumble::Turbo::ModelTemplateRefreshResource.uri_path, headers: submitting_headers, session_store: session_store)
+      other_subscriber_request_ctx = Crumble::Server::TestRequestContext.new(method: "GET", resource: Crumble::Turbo::ModelTemplateRefreshResource.uri_path, headers: other_headers, session_store: session_store)
+      submitting_subscriber_ctx = Crumble::Server::HandlerContext.new(submitting_subscriber_request_ctx, TestViewHandler.new(submitting_subscriber_request_ctx))
+      other_subscriber_ctx = Crumble::Server::HandlerContext.new(other_subscriber_request_ctx, TestViewHandler.new(other_subscriber_request_ctx))
+      submitting_channel = Crumble::Turbo::ModelTemplateRefreshService.subscribe(submitting_subscriber_ctx)
+      other_channel = Crumble::Turbo::ModelTemplateRefreshService.subscribe(other_subscriber_ctx)
+
+      begin
+        Crumble::Turbo::ModelTemplateRefreshService.register(submitting_subscriber_ctx, model_template_id)
+        Crumble::Turbo::ModelTemplateRefreshService.register(other_subscriber_ctx, model_template_id)
+
+        response = String.build do |io|
+          post_ctx = Crumble::Server::TestRequestContext.new(response_io: io, method: "POST", resource: "/a/orma/model_action_spec/my_model/#{model_id}/inc_some_number", headers: submitting_headers, session_store: session_store)
+          MyModel::IncSomeNumberAction.handle(post_ctx)
+          post_ctx.response.flush
+        end
+
+        3.times { Fiber.yield }
+        response.scan("data-model-template-id=\"#{model_template_id}\"").size.should eq(1)
+
+        submitting_refresh = nil
+        select
+        when submitting_refresh = submitting_channel.receive
+        when timeout(10.milliseconds)
+        end
+        submitting_refresh.should be_nil
+
+        other_refresh = nil
+        select
+        when other_refresh = other_channel.receive
+        when timeout(1.second)
+        end
+        other_refresh.should_not be_nil
+      ensure
+        Crumble::Turbo::ModelTemplateRefreshService.unsubscribe(submitting_subscriber_ctx)
+        Crumble::Turbo::ModelTemplateRefreshService.unsubscribe(other_subscriber_ctx)
+      end
+    end
   end
 
   describe "policies for model actions" do

--- a/src/crumble/turbo/model_template_refresh_service.cr
+++ b/src/crumble/turbo/model_template_refresh_service.cr
@@ -5,6 +5,8 @@ require "opentelemetry-sdk"
 module Crumble
   module Turbo
     module ModelTemplateRefreshService
+      alias SessionFilter = ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)
+
       record Subscription, ctx : ::Crumble::Server::HandlerContext, channel : Channel(TurboStream(IdentifiableView)), connection_span_context : OpenTelemetry::SpanContext?
 
       @@subscriptions = {} of ::Crumble::Server::SessionKey => Subscription
@@ -36,14 +38,14 @@ module Crumble
         (@@model_template_subscriptions[model_template_id] ||= Set(::Crumble::Server::SessionKey).new) << ctx.session.id
       end
 
-      def self.refresh_model_template_id(model_template_id : String, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil) : Nil
+      def self.refresh_model_template_id(model_template_id : String, *, only : SessionFilter? = nil, except : SessionFilter? = nil) : Nil
         return unless parsed = parse_model_template_id(model_template_id)
 
         model_class_name, model_id_str, template_name = parsed
-        refresh_model_template(model_class_name, model_id_str, template_name, only: only)
+        refresh_model_template(model_class_name, model_id_str, template_name, only: only, except: except)
       end
 
-      def self.refresh_model_template(model_class_name : String, model_id : String | Int32 | Int64, template_name : String, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil)
+      def self.refresh_model_template(model_class_name : String, model_id : String | Int32 | Int64, template_name : String, *, only : SessionFilter? = nil, except : SessionFilter? = nil)
         {% begin %}
           case model_class_name
             {% for klass in ::Orma::Record.all_subclasses.reject(&.abstract?) %}
@@ -91,7 +93,7 @@ module Crumble
               case template_name
                 {% for method in klass.methods.select { |m| m.annotation(::Orma::Record::ModelTemplateMethod) } %}
                 when {{method.name.stringify}}
-                  notify(%model.{{method.name}}, only: only)
+                  notify(%model.{{method.name}}, only: only, except: except)
                 {% end %}
               end
             {% end %}
@@ -99,24 +101,37 @@ module Crumble
         {% end %}
       end
 
-      def self.notify(model_template, *, only : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil)
+      def self.notify(model_template, *, only : SessionFilter? = nil, except : SessionFilter? = nil)
         return unless ids = @@model_template_subscriptions[model_template.dom_id.attr_value]?
 
         stale_ids = Set(::Crumble::Server::SessionKey).new
+        excluded_ids = Set(::Crumble::Server::SessionKey).new
+
+        case except
+        in Nil
+        in ::Crumble::Server::SessionKey
+          excluded_ids << except
+        in Enumerable(::Crumble::Server::SessionKey)
+          except.each { |id| excluded_ids << id }
+        end
 
         case only
         in Nil
           ids.each do |id|
+            next if excluded_ids.includes?(id)
+
             stale_ids << id unless send_model_template_to_subscription(model_template, id)
           end
         in ::Crumble::Server::SessionKey
           id = only
           return unless ids.includes?(id)
+          return if excluded_ids.includes?(id)
 
           stale_ids << id unless send_model_template_to_subscription(model_template, id)
         in Enumerable(::Crumble::Server::SessionKey)
           only.each do |id|
             next unless ids.includes?(id)
+            next if excluded_ids.includes?(id)
 
             stale_ids << id unless send_model_template_to_subscription(model_template, id)
           end

--- a/src/orma/model_action.cr
+++ b/src/orma/model_action.cr
@@ -106,7 +106,7 @@ module Orma
       if templates = refreshed_model_templates
         templates.each do |tpl|
           tpl.renderer(ctx).turbo_stream.to_html(ctx.response)
-          tpl.refresh!
+          tpl.refresh!(except: ctx.session.id)
         end
       end
     end

--- a/src/orma/model_template.cr
+++ b/src/orma/model_template.cr
@@ -33,10 +33,10 @@ class Orma::Record
         Renderer.new(ctx: ctx, model_template: self)
       end
 
-      def refresh!
+      def refresh!(*, except : ::Crumble::Server::SessionKey | Enumerable(::Crumble::Server::SessionKey)? = nil)
         raise ArgumentError.new("Cannot render model template for unpersisted record") unless id = model.id
 
-        ::Crumble::Turbo::ModelTemplateRefreshService.refresh_model_template({{@type.name.stringify}}, id.value, {{method_name.id.stringify}})
+        ::Crumble::Turbo::ModelTemplateRefreshService.refresh_model_template({{@type.name.stringify}}, id.value, {{method_name.id.stringify}}, except: except)
       end
 
       private struct Renderer


### PR DESCRIPTION
## Summary
- Exclude the submitting session when model actions broadcast refreshed templates.
- Preserve direct Turbo Stream refreshes in the POST response.
- Add regression coverage for same-session suppression while other subscribers still receive broadcasts.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crt-crystal-cache crystal spec`