### PR TITLE
Reset submitted action forms to fresh instances

### DIFF
--- a/spec/action_form_request_spec.cr
+++ b/spec/action_form_request_spec.cr
@@ -59,6 +59,8 @@ module Crumble::Turbo::ActionFormRequestSpec
         action = PayloadAction.new(ctx)
         action.handle
         action.form.name.should be_nil
+        action.form.submitted?.should be_false
+        action.form.errors.should be_nil
         ctx.response.flush
       end
 

--- a/spec/orma/create_child_action_spec.cr
+++ b/spec/orma/create_child_action_spec.cr
@@ -172,8 +172,12 @@ describe "MyModel #add_child_action_template" do
       model = CreateChildSpec::MyModel.create(name: "Allowed")
       response = String.build do |io|
         ctx = Crumble::Server::TestRequestContext.new(method: "POST", resource: "/a/create_child_spec/my_model/#{model.id.value}/add_child_with_dynamic_options", body: URI::Params.encode({name: "Allowed"}), response_io: io)
-        CreateChildSpec::MyModel::AddChildWithDynamicOptionsAction.handle(ctx)
+        action = CreateChildSpec::MyModel::AddChildWithDynamicOptionsAction.new(ctx, model)
+        action.handle
         ctx.response.status_code.should eq(201)
+        action.form.name.should be_nil
+        action.form.submitted?.should be_false
+        action.form.errors.should be_nil
         ctx.response.flush
       end
 

--- a/src/crumble/turbo/action.cr
+++ b/src/crumble/turbo/action.cr
@@ -7,7 +7,7 @@ module Crumble::Turbo
     def reset_form
       return unless (request_form = form).submitted? && request_form.valid?
 
-      @form = nil
+      @form = fresh_form
     end
   end
 
@@ -130,6 +130,10 @@ module Crumble::Turbo
         else
           Form.new(ctx)
         end
+      end
+
+      def fresh_form : Form
+        Form.new(ctx)
       end
 
       include ::Crumble::Turbo::RequestBackedFormReset

--- a/src/orma/model_action.cr
+++ b/src/orma/model_action.cr
@@ -62,6 +62,10 @@ module Orma
         end
       end
 
+      def fresh_form : Form
+        Form.new(ctx, model)
+      end
+
       include ::Crumble::Turbo::RequestBackedFormReset
     end
 


### PR DESCRIPTION
## Summary
- Reset valid submitted action forms to fresh memoized instances instead of clearing them
- Add fresh reset handling for model-aware action forms
- Tighten regression specs for normal and model action forms

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/crt-crystal-cache crystal spec`